### PR TITLE
fix wireguard-kmod references for mco 4.7+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,8 @@
-ifndef DESTDIR
-DESTDIR=/usr/
-endif
-ifndef CONFDIR
-CONFDIR=/etc
+ifndef FAKEROOT
+FAKEROOT=/tmp/tigera-wireguard-kvc/
 endif
 
 install:
-	install -v -m 644 wireguard-kmod-lib.sh $(DESTDIR)/lib/kvc/
-	install -v -m 644 wireguard-kmod.conf $(CONFDIR)/kvc/
-	install -v -m 755 wireguard-kmod-wrapper.sh $(DESTDIR)/lib/kvc/
-	ln -sf ../lib/kvc/wireguard-kmod-wrapper.sh $(DESTDIR)/bin/wg
+	install -v -m 644 wireguard-kmod-lib.sh $(FAKEROOT)/etc/kvc/lib/kvc/
+	install -v -m 644 wireguard-kmod.conf $(FAKEROOT)/etc/kvc/
+	install -v -m 755 wireguard-kmod-wrapper.sh $(FAKEROOT)/etc/kvc/lib/kvc/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ FAKEROOT=/tmp/tigera-wireguard-kvc/
 endif
 
 install:
-	install -v -m 644 wireguard-kmod-lib.sh $(FAKEROOT)/etc/kvc/lib/kvc/
-	install -v -m 644 wireguard-kmod.conf $(FAKEROOT)/etc/kvc/
-	install -v -m 755 wireguard-kmod-wrapper.sh $(FAKEROOT)/etc/kvc/lib/kvc/
+	install -v -m 644 wireguard-kmod-lib.sh $(FAKEROOT)/root/etc/kvc/lib/kvc/
+	install -v -m 644 wireguard-kmod.conf $(FAKEROOT)/root/etc/kvc/
+	install -v -m 755 wireguard-kmod-wrapper.sh $(FAKEROOT)/root/etc/kvc/lib/kvc/
+
+ignition:
+	butane --pretty -d $(FAKEROOT) < config.bu

--- a/config.bu
+++ b/config.bu
@@ -1,0 +1,9 @@
+variant: openshift
+version: 4.8.0
+storage:
+  trees:
+  - local: root
+metadata:
+  name: 10-kvc-wireguard-kmod
+  labels:
+    machineconfiguration.openshift.io/role: worker

--- a/wireguard-kmod-wrapper.sh
+++ b/wireguard-kmod-wrapper.sh
@@ -3,5 +3,5 @@
 # This is a thin wrapper that maps userspace tools (executables)
 # to a container where they can be run.
 
-kmods-via-containers wrapper wireguard-kmod $(uname -r) $(basename $0) $@
-#kmods-via-containers wrapper wireguard-kmod $@
+# /etc/kvc/bin is set in github.com/tigera/kmods-via-containers
+/etc/kvc/bin/kmods-via-containers wrapper wireguard-kmod $(uname -r) $(basename $0) $@


### PR DESCRIPTION
now that /usr/local ignition paths are not allowed, we now need to hardcode our bin/script paths.